### PR TITLE
`TestStore` can support testing failures

### DIFF
--- a/Sources/ComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/ComposableArchitecture/TestSupport/TestStore.swift
@@ -247,7 +247,7 @@
           runReducer(action: receivedAction)
           update(&expectedState)
 
-        case let .failure(expectedError, update):
+        case let .fail(assertOn, update):
           guard let receivedError = receivedError else {
             _XCTFail(
               """
@@ -258,20 +258,8 @@
             )
             break
           }
-          
-          let receivedErrorType = type(of: receivedError)
-          let expectedErrorType = type(of: expectedError)
-          guard receivedErrorType == expectedErrorType else {
-            _XCTFail(
-              """
-              Expected error's type, \(expectedErrorType), does not match the received error's type, \(receivedErrorType)."
-              """,
-              file: step.file,
-              line: step.line
-            )
-            break
-          }
 
+          assertOn(receivedError)
           update(&expectedState)
 
         case let .environment(work):
@@ -428,17 +416,17 @@
       /// state is expected to change.
       ///
       /// - Parameters:
-      ///   - error: The error the test store should receive by evaluating an effect.
+      ///   - assertOn: A closure which can inspect and assert on the error received by the store.
       ///   - update: A function that describes how the test store's state is expected to change.
       /// - Returns: A step that describes an action received by an effect and asserts against how
       ///   the store's state is expected to change.
       public static func fail(
-        _ error: Error,
         file: StaticString = #file,
         line: UInt = #line,
+        assertOn: @escaping (Error) -> Void = { _ in },
         _ update: @escaping (inout LocalState) -> Void = { _ in }
       ) -> Step {
-        Step(.failure(error, update), file: file, line: line)
+        Step(.fail(assertOn, update), file: file, line: line)
       }
 
       /// A step that updates a test store's environment.
@@ -469,7 +457,7 @@
       fileprivate enum StepType {
         case send(LocalAction, (inout LocalState) -> Void)
         case receive(Action, (inout LocalState) -> Void)
-        case failure(Error, (inout LocalState) -> Void)
+        case fail((Error) -> Void, (inout LocalState) -> Void)
         case environment((inout Environment) -> Void)
       }
     }


### PR DESCRIPTION
This isn't completely ideal as the assertion only checks that the error types match. I couldn't figure out a way to assert on the actual error instances and their associated values or properties without having to get into the low level memory stuff. I tried reflection but ultimately, it results in trying to compare `Any` instances, which is like the same problem. If anyone has any ideas, please let's try. 

Otherwise, I tested this works in the app tests as expected. 